### PR TITLE
Fixed crash error in Android

### DIFF
--- a/android/src/main/java/com/itrabbit/imageCapInsets/utils/RCTImageLoaderTask.java
+++ b/android/src/main/java/com/itrabbit/imageCapInsets/utils/RCTImageLoaderTask.java
@@ -23,6 +23,10 @@ public class RCTImageLoaderTask extends AsyncTask<String, Void, Bitmap> {
 
     @Override
     protected Bitmap doInBackground(String... params) {
+        if (mUri == null) {
+            return null;
+        }
+        
         if (mUri.startsWith("http")) {
             return loadBitmapByExternalURL(mUri);
         }


### PR DESCRIPTION
In Android, there's a case that `mUri` becomes null, it causes app crash directly.